### PR TITLE
[BD-43] Show usernames in private chat

### DIFF
--- a/client/src/components/friends/FriendSidebar.jsx
+++ b/client/src/components/friends/FriendSidebar.jsx
@@ -19,13 +19,11 @@ export default function FriendSidebar(props) {
                 {
                   privateChatId === chat.id
                     ? (
-                      // eslint-disable-next-line
                       <Link style={{ color: '#b5fff3' }} to={{ pathname: `/friends/${chat.id}` }}>
                         {chat.name}
                       </Link>
                     )
                     : (
-                      // eslint-disable-next-line
                       <Link className="text-reset" to={{ pathname: `/friends/${chat.id}` }}>
                         {chat.name}
                       </Link>
@@ -56,5 +54,4 @@ export default function FriendSidebar(props) {
 FriendSidebar.propTypes = {
   // eslint-disable-next-line
   privateChats: PropTypes.array.isRequired,
-
 };

--- a/client/src/components/friends/Friends.jsx
+++ b/client/src/components/friends/Friends.jsx
@@ -3,11 +3,13 @@ import { useParams } from 'react-router-dom';
 import FriendSidebar from './FriendSidebar';
 import FriendHome from './FriendHome';
 import PrivateChat from './chat/PrivateChat';
+import Loading from '../Loading';
 
 export default function Friend() {
   const [friends, setFriends] = useState([]);
   const [friendRequests, setFriendRequests] = useState([]);
   const [privateChats, setPrivateChats] = useState([]);
+  const [loading, setLoading] = useState(true);
   const [error, setError] = useState();
   const { privateChatId } = useParams();
 
@@ -42,8 +44,10 @@ export default function Friend() {
         if (data.success) setPrivateChats(data.privateChats);
         else setError(data.message);
       });
+    setLoading(false);
   }, []);
 
+  if (loading) return <Loading />;
   return (
     <>
       <div className="col-1" style={{ minHeight: '100vh', background: '#292929' }}>

--- a/client/src/components/friends/Friends.jsx
+++ b/client/src/components/friends/Friends.jsx
@@ -49,7 +49,7 @@ export default function Friend() {
       <div className="col-1" style={{ minHeight: '100vh', background: '#292929' }}>
         <FriendSidebar privateChats={privateChats} />
       </div>
-      {privateChatId ? <PrivateChat />
+      {privateChatId ? <PrivateChat privateChat={privateChats.find((privateChat) => privateChat.id === privateChatId)} />
         : <FriendHome friends={friends} friendRequests={friendRequests} setFriends={setFriends} setFriendRequests={setFriendRequests} />}
     </>
 

--- a/client/src/components/friends/chat/PrivateChat.jsx
+++ b/client/src/components/friends/chat/PrivateChat.jsx
@@ -1,6 +1,7 @@
 import React, {
   useState, useEffect, useContext, useMemo,
 } from 'react';
+import PropTypes from 'prop-types';
 import { useParams } from 'react-router-dom';
 import { Context } from '../../../contexts/Store';
 import { ChatLogsContext } from '../../../contexts/chatLogs-context';
@@ -8,13 +9,17 @@ import { PendingMessagesContext } from '../../../contexts/pendingMessages-contex
 import { UserContext } from '../../../contexts/user-context';
 import Loading from '../../Loading';
 
-export default function PrivateChat() {
+export default function PrivateChat(props) {
+  const {
+    privateChat,
+  } = props;
   const [state, setState] = useContext(Context);
   const [user, setUser] = useContext(UserContext);
   const [chatLogs, setChatLogs] = useContext(ChatLogsContext);
   const [pendingMessages, setPendingMessages] = useContext(PendingMessagesContext);
   const [loading, setLoading] = useState(true);
   const [input, setInput] = useState('');
+  const [users, setUsers] = useState(privateChat.users);
   const { privateChatId } = useParams();
 
   useEffect(async () => {
@@ -75,7 +80,7 @@ export default function PrivateChat() {
     if (pendingMessages[privateChatId]) {
       return Object.entries(pendingMessages[privateChatId]).map(([key, value]) => (
         <p className="ml-2 #858585" key={key}>
-          {value.author}
+          {users[value.author].name}
           {' '}
           (
           {new Date(value.timestamp).toLocaleString()}
@@ -94,7 +99,7 @@ export default function PrivateChat() {
           <div className="col-12" aria-orientation="vertical" style={{ height: '100%', position: 'absolute', overflowY: 'scroll' }}>
             { Object.entries(chatLogs[privateChatId]).map(([key, value]) => (
               <p className="ml-2" style={{ color: '#c2c2c2' }} key={key}>
-                {value.author}
+                {users[value.author].name}
                 {' '}
                 (
                 {new Date(value.timestamp).toLocaleString()}
@@ -127,3 +132,8 @@ export default function PrivateChat() {
     </div>
   );
 }
+
+PrivateChat.propTypes = {
+  // eslint-disable-next-line
+  privateChat: PropTypes.object.isRequired,
+};


### PR DESCRIPTION
- Private chats now show usernames based off the user object from backend
- Added loading when loading all friend api gets stuff
- Added the selected private chat as a prop since it holds the users as well
Note there's a bug in PrivateChat.jsx if you try to do `setUsers(privateChat.users)` in the useEffect so I left it in the useState lol